### PR TITLE
fix: Make ion-segments sticky by moving them to the header

### DIFF
--- a/src/app/pages/list.page.html
+++ b/src/app/pages/list.page.html
@@ -5,45 +5,43 @@
       <ion-button fill="outline" routerLink="/login">Giriş Yap</ion-button>
     </ion-buttons>
   </ion-toolbar>
+  <ion-toolbar>
+    <ion-segment [(ngModel)]="category">
+      <ion-segment-button value="all">
+        <ion-label>Tüm Yazılar</ion-label>
+      </ion-segment-button>
+      <ion-segment-button value="art">
+        <ion-label>Sanat</ion-label>
+      </ion-segment-button>
+
+      <ion-segment-button value="music">
+        <ion-label>Müzik</ion-label>
+      </ion-segment-button>
+
+      <ion-segment-button value="food">
+        <ion-label>Yemek</ion-label>
+      </ion-segment-button>
+
+      <ion-segment-button value="science">
+        <ion-label>Bilim</ion-label>
+      </ion-segment-button>
+
+
+      <ion-segment-button value="ion">
+        <ion-label>İonic</ion-label>
+      </ion-segment-button>
+      <ion-segment-button value="flut">
+        <ion-label>Flutter</ion-label>
+      </ion-segment-button>
+      <ion-segment-button value="tek">
+        <ion-label>Teknoloji</ion-label>
+      </ion-segment-button>
+
+    </ion-segment>
+  </ion-toolbar>
 </ion-header>
 
-
-
-
 <ion-content>
-  <ion-segment [(ngModel)]="category">
-    <ion-segment-button value="all">
-      <ion-label>Tüm Yazılar</ion-label>
-    </ion-segment-button>
-    <ion-segment-button value="art">
-      <ion-label>Sanat</ion-label>
-    </ion-segment-button>
-
-    <ion-segment-button value="music">
-      <ion-label>Müzik</ion-label>
-    </ion-segment-button>
-
-    <ion-segment-button value="food">
-      <ion-label>Yemek</ion-label>
-    </ion-segment-button>
-
-    <ion-segment-button value="science">
-      <ion-label>Bilim</ion-label>
-    </ion-segment-button>
-
-
-    <ion-segment-button value="ion">
-      <ion-label>İonic</ion-label>
-    </ion-segment-button>
-    <ion-segment-button value="flut">
-      <ion-label>Flutter</ion-label>
-    </ion-segment-button>
-    <ion-segment-button value="tek">
-      <ion-label>Teknoloji</ion-label>
-    </ion-segment-button>
-    
-  </ion-segment>
-
   <ion-list>
     <ion-card *ngFor="let article of filteredArticles" [routerLink]="['/article', article.id]">
       <ion-card-header>

--- a/src/app/pages/list2.page.html
+++ b/src/app/pages/list2.page.html
@@ -5,15 +5,16 @@
       <ion-button fill="outline" (click)="logout()">Çıkış Yap</ion-button>
     </ion-buttons>
   </ion-toolbar>
+  <ion-toolbar>
+    <ion-segment [(ngModel)]="category">
+      <ion-segment-button *ngFor="let segment of segments" [value]="segment.value">
+        <ion-label>{{ segment.label }}</ion-label>
+      </ion-segment-button>
+    </ion-segment>
+  </ion-toolbar>
 </ion-header>
 
 <ion-content>
-  <ion-segment [(ngModel)]="category">
-    <ion-segment-button *ngFor="let segment of segments" [value]="segment.value">
-      <ion-label>{{ segment.label }}</ion-label>
-    </ion-segment-button>
-  </ion-segment>
-
   <ion-list>
     <ion-card *ngFor="let article of filteredArticles" [routerLink]="['/article', article.id]">
       <ion-card-header>


### PR DESCRIPTION
Moves the ion-segment components on the list pages to a new ion-toolbar inside the ion-header. This makes them sticky, so they remain at the top of the viewport when scrolling.